### PR TITLE
Release/1.2.5

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,3 @@
 REACT_APP_Environnement=DEV
-REACT_APP_appVersion=1.2.5
+REACT_APP_appVersion=1.2.6
 REACT_APP_apiVersion=7.5.4

--- a/src/components/api/pqtApi.js
+++ b/src/components/api/pqtApi.js
@@ -96,7 +96,7 @@ export async function loadPreset({ name = "", bank = "", dispatch = null }) {
 }
 
 export async function savePreset({ name = "My new preset", bank = "My Presets", dispatch = null }) {
-    return postCommand("savePreset", { name: name, bank: bank }).then(() => {
+    return postCommand("savePreset", { name: name, bank: bank ? bank : "My Presets" }).then(() => {
         if (dispatch) {
             //Need to refresh the context as this might be a new preset and we need to populate the navigation menu
             loadPreset({name: name, bank: bank, dispatch}).then(()=>refreshCurrentContext(dispatch));

--- a/src/components/domain/presets.js
+++ b/src/components/domain/presets.js
@@ -18,7 +18,8 @@ export function factoryPresets(value=[]) {
     return {
         presets: value,
         classes: initArray(value, "class"),
-        collections: initArray(value, "collection")
+        collections: initArray(value, "collection"),
+        banks: initArray(value, "bank")
     }
 }
 

--- a/src/components/ui/instrumentsViews.js
+++ b/src/components/ui/instrumentsViews.js
@@ -1,12 +1,12 @@
 import React, { useState } from "react";
-import { Accordion, Button, Card, Collapse, Form, ListGroup, Modal } from "react-bootstrap";
+import { Accordion, Button, Card, Collapse, Dropdown, DropdownButton, Form, InputGroup, ListGroup, Modal } from "react-bootstrap";
 import { listPresetsForBank, listInstrumentsForClass, listPresetsForInstruments } from "../domain/presets";
 import { useInstrumentContext } from "../utils/instrumentContext";
 import * as pqtApi from '../api/pqtApi';
 
 export const InstrumentSelectionPaneView = ({ toggleFunction }) => {
     const [ctx] = useInstrumentContext();
-    const instrumentItems = ctx.allInstruments.classes.map((c) => {
+    const allPresetsByClasses = ctx.allInstruments.classes.map((c) => {
         return (
             <Accordion.Item key={c} eventKey={c}>
                 <Accordion.Header>{c}</Accordion.Header>
@@ -17,15 +17,23 @@ export const InstrumentSelectionPaneView = ({ toggleFunction }) => {
         );
     });
 
+    const allPresetsByBanks = ctx.allInstruments.banks.map((b) => {
+        if (b) {
+            return (
+                <Accordion.Item key={b} eventKey={b}>
+                    <Accordion.Header>Bank - {b}</Accordion.Header>
+                    <Accordion.Body>
+                        <AccordionInstrumentsForBank bank={b} presets={ctx.allInstruments.presets} toggleView={toggleFunction} />
+                    </Accordion.Body>
+                </Accordion.Item>
+            );
+        }
+    });
+
     return (
         <Accordion>
-            <Accordion.Item eventKey="0">
-                <Accordion.Header>My presets</Accordion.Header>
-                <Accordion.Body>
-                    <AccordionInstrumentsForBank presets={ctx.allInstruments.presets} toggleView={toggleFunction} />
-                </Accordion.Body>
-            </Accordion.Item>
-            {instrumentItems}
+            {allPresetsByBanks}
+            {allPresetsByClasses}
         </Accordion>
     );
 }
@@ -144,20 +152,23 @@ export const SavePresetController = () => {
 
 export const SavePresetControlView = ({ preset = {}, reducer }) => {
     const [hasClicked, setHasClicked] = useState(false);
-
-    const onSave = (name) => { setHasClicked(false); pqtApi.savePreset({ name: name, dispatch: reducer }) }
+    
+    const onSave = (name, bank) => { setHasClicked(false); pqtApi.savePreset({ name: name, bank: bank, dispatch: reducer }) }
 
     return (
         <>
             {!hasClicked && (<Button className="me-2" onClick={(e) => { e.preventDefault(); e.stopPropagation(); setHasClicked(true); }}>Save</Button>)}
-            {hasClicked && (<ModalSaveView presetName={preset.name} show={hasClicked} handleClose={() => setHasClicked(false)} handleSave={onSave} />)}
+            {hasClicked && (<ModalSaveView presetName={preset.name} presetBank={preset.bank} show={hasClicked} handleClose={() => setHasClicked(false)} handleSave={onSave} />)}
         </>
 
     );
 }
 
-export const ModalSaveView = ({ show, handleClose, handleSave, presetName = "Not set" }) => {
-    const [pn, setPresetName] = useState(presetName)
+export const ModalSaveView = ({ show, handleClose, handleSave, presetName = "Not set", presetBank = "My Preset" }) => {
+    const [form, setForm] = useState({ pn: presetName, bank: presetBank });
+    const [ctx, ] = useInstrumentContext();
+    const handleBankSelection = (val) => setForm({ pn: form.pn, bank: val });
+    
     return (
         <Modal show={show} onHide={handleClose}>
             <Modal.Header closeButton>
@@ -166,18 +177,32 @@ export const ModalSaveView = ({ show, handleClose, handleSave, presetName = "Not
             <Modal.Body>
                 <Form.Group className="mb-3" controlId="pnId1">
                     <Form.Label>Preset name</Form.Label>
-                    <Form.Control type="text" value={pn} placeholder={presetName} onChange={(e) => setPresetName(e.target.value)} />
+                    <Form.Control type="text" value={form.pn} placeholder="Name of your preset" onChange={(e) => setForm({ pn: e.target.value, bank: form.bank })} />
                 </Form.Group>
+                <InputGroup className="mb-3">
+                    <DropdownButton variant="outline-secondary" title="Bank name" id="input-group-dropdown-1" onSelect={handleBankSelection}>
+                        <ItemListView banks={ctx.allInstruments.banks}/>
+                    </DropdownButton>
+                    <Form.Control type="text" value={form.bank} placeholder="Provide a bank name" onChange={(e) => setForm({ pn: form.pn, bank: e.target.value })} />
+                </InputGroup>
             </Modal.Body>
             <Modal.Footer>
                 <Button variant="secondary" onClick={handleClose}>
                     Close
                 </Button>
-                <Button variant="primary" onClick={() => handleSave(pn)}>
+                <Button variant="primary" onClick={() => handleSave(form.pn, form.bank)}>
                     Save Changes
                 </Button>
             </Modal.Footer>
         </Modal>
     );
 
+}
+
+const ItemListView = ({ banks = [] }) => {
+    return (
+        <>
+            {banks.map((b) => b ? (<Dropdown.Item eventKey={b} key={b}>{b}</Dropdown.Item>) : null)}
+        </>
+    );
 }

--- a/src/components/ui/instrumentsViews.js
+++ b/src/components/ui/instrumentsViews.js
@@ -107,10 +107,17 @@ export const InstrumentCardView = ({ instrument, dispatch }) => {
                     <Card.Title><div className="d-flex justify-content-between"><div>{instrument.name}</div><SavePresetController /></div></Card.Title>
                     <Card.Subtitle>{instrument.collection} <i onClick={(e) => { e.preventDefault(); e.stopPropagation(); setShow(!show) }} className={iconClassName} /></Card.Subtitle>
                     <Collapse in={show}>
-                        <Card.Text>{instrument.comment}<br /><InstrumentRegistrationView instrument={instrument} /></Card.Text>
+                        <span>
+                            <Card.Text><span>{instrument.comment}</span></Card.Text>
+                            <Card.Text>
+                                <InstrumentRegistrationView instrument={instrument} />
+                                <br />
+                                <strong>Bank</strong>: {instrument.bank}
+                            </Card.Text>
+                        </span>
                     </Collapse>
                 </Card.Body>
-            </Card>
+            </Card >
         );
     }
 
@@ -152,7 +159,7 @@ export const SavePresetController = () => {
 
 export const SavePresetControlView = ({ preset = {}, reducer }) => {
     const [hasClicked, setHasClicked] = useState(false);
-    
+
     const onSave = (name, bank) => { setHasClicked(false); pqtApi.savePreset({ name: name, bank: bank, dispatch: reducer }) }
 
     return (
@@ -166,9 +173,9 @@ export const SavePresetControlView = ({ preset = {}, reducer }) => {
 
 export const ModalSaveView = ({ show, handleClose, handleSave, presetName = "Not set", presetBank = "My Preset" }) => {
     const [form, setForm] = useState({ pn: presetName, bank: presetBank });
-    const [ctx, ] = useInstrumentContext();
+    const [ctx,] = useInstrumentContext();
     const handleBankSelection = (val) => setForm({ pn: form.pn, bank: val });
-    
+
     return (
         <Modal show={show} onHide={handleClose}>
             <Modal.Header closeButton>
@@ -181,7 +188,7 @@ export const ModalSaveView = ({ show, handleClose, handleSave, presetName = "Not
                 </Form.Group>
                 <InputGroup className="mb-3">
                     <DropdownButton variant="outline-secondary" title="Bank name" id="input-group-dropdown-1" onSelect={handleBankSelection}>
-                        <ItemListView banks={ctx.allInstruments.banks}/>
+                        <ItemListView banks={ctx.allInstruments.banks} />
                     </DropdownButton>
                     <Form.Control type="text" value={form.bank} placeholder="Provide a bank name" onChange={(e) => setForm({ pn: form.pn, bank: e.target.value })} />
                 </InputGroup>


### PR DESCRIPTION
Feature - Support multiple banks

This PR allows for users to select/create a bank when saving a presets.

### Changes

* Added support for multiple banks in the instruments selection menu
* Added bank input control to allow user to select or enter a new bank when saving a preset
* Adapted the client API to support the specified bank
* Added the list of banks in the context
* Added bank info in the instrument card view

### Known issues

* Saving an existing presets into a different banks, will not move the preset but simply create a new one
    * Workaround - Need to use the preset manager in Pianoteq to remove the other one
* The application behave badly when saving a presets that has the same name as another one in a different bank
    * Workaround - Need to make sure that you have unique name when saving.